### PR TITLE
Fix dead links per upstream move from shretl.org to okey.kompyuter.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Windows version: https://github.com/heyheydanhey/yiddish-keys-windows
 
 OSX version: https://github.com/heyheydanhey/yiddish-keys-osx
 
-More info: http://www.shretl.org
+More info: http://www.okey.kompyuter.net/klaviatur
 
 **"But didn't you know you can write Yiddish with a Hebrew layout?"**  
 **"*Nu*, tell me something I don't know!"**

--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 Yiddish keyboard layout for GNU/Linux
 
-Windows version: https://github.com/heyheydanhey/yiddish-keys-windows
+Windows and OSX versions: https://gitlab.com/okey_kompyuter/yiddish-klaviator
 
-OSX version: https://github.com/heyheydanhey/yiddish-keys-osx
-
-More info: http://www.okey.kompyuter.net/klaviatur
+More info: https://okey.kompyuter.net/klaviatur
 
 **"But didn't you know you can write Yiddish with a Hebrew layout?"**  
 **"*Nu*, tell me something I don't know!"**
@@ -23,7 +21,7 @@ This Yiddish keyboard hopes to address this by providing an intuitive and eventu
 standard Yiddish keyboard for all major OSs to ultimately, it is hoped, include 
 as a vanilla feature.
 
-This is a pared-down version of [heyheydanhey](https://github.com/heyheydanhey)'s version&mdash;just the QWERTY layout.
+This is a pared-down version of [heyheydanhey](https://gitlab.com/okey_kompyuter/yiddish-keys-linux)'s version&mdash;just the QWERTY layout.
 
 ## Installation
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 # Installer for Yiddish keyboard map. 
 #
-# http://www.okey.kompyuter.net/klaviatur
+# https://okey.kompyuter.net/klaviatur
 
 # Run ./install.sh
 # Then activate via Settings -> Keyboard -> Keyboard Layouts -> add layout 
@@ -36,5 +36,5 @@ sudo sed -i '/yi              Yiddish/d; // cleanup
 echo '
 Success! The Yiddish keyboard map has been installed.
 To activate it in your operating system, see Settings -> Keyboard -> Keyboard Layouts -> add layout
-See http://www.okey.kompyuter.net/klaviatur for more information.
+See https://okey.kompyuter.net/klaviatur for more information.
 '

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 # Installer for Yiddish keyboard map. 
 #
-# http://www.shretl.org
+# http://www.okey.kompyuter.net/klaviatur
 
 # Run ./install.sh
 # Then activate via Settings -> Keyboard -> Keyboard Layouts -> add layout 
@@ -36,5 +36,5 @@ sudo sed -i '/yi              Yiddish/d; // cleanup
 echo '
 Success! The Yiddish keyboard map has been installed.
 To activate it in your operating system, see Settings -> Keyboard -> Keyboard Layouts -> add layout
-See http://www.shretl.org for more information.
+See http://www.okey.kompyuter.net/klaviatur for more information.
 '

--- a/yi
+++ b/yi
@@ -3,7 +3,7 @@
 // Source:
 // https://github.com/heyheydanhey/yiddish-keys-linux
 //
-// http://www.shretl.org
+// http://www.okey.kompyuter.net/klaviatur
 
 
 default partial alphanumeric_keys

--- a/yi
+++ b/yi
@@ -1,9 +1,9 @@
 // Yiddish keyboard map
 //
 // Source:
-// https://github.com/heyheydanhey/yiddish-keys-linux
+// https://gitlab.com/okey_kompyuter/yiddish-keys-linux
 //
-// http://www.okey.kompyuter.net/klaviatur
+// https://okey.kompyuter.net/klaviatur
 
 
 default partial alphanumeric_keys


### PR DESCRIPTION
Shretl.org no longer exists on the internet, the successor project is [Okey Kompyuter](https://okey.kompyuter.net/klaviatur/). 

Furthermore the upstream code has been moved from heyheydanhey's github to the Okey Kompyuter gitlab.

This patch updates the links in docs and comments to reflect this.

NOTE that the PR can't change the project description's URL which also needs to be updated in the github UI. It should be changed from http://shretl.org to https://okey.kompyuter.net/klaviatur/

No code changes.